### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.3.0 - 29-04-22
+## 1.4.0 - 29-04-22
 ### Added
 - Version number to `composer.json`.
 - Field time changes can be disabled within plugin settings.
@@ -19,6 +19,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Bug where incorrect value was shown for month day repeat on entry load.
+
+## 1.3.0 - 2020-10-26
+**Undocumented**
 
 ## 1.2.18 - 2020-10-26
 **Undocumented**

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unionco/calendarize",
     "description": "A calendar field type providing functionality for recurrence.",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "type": "craft-plugin",
     "keywords": [
         "craft",


### PR DESCRIPTION
### Junior Review:
Yes

### Context:
There is another un-versioned release at 1.3.0.

This bumps us to 1.4.0.
