### PR TITLE
Set endRepeatDate time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.4.1 - 23-05-22
+### Fixed
+- `endRepeatDate` `DateTime` object time manually set to end of day (23:59:59).
+
 ## 1.4.0 - 29-04-22
 ### Added
 - Version number to `composer.json`.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unionco/calendarize",
     "description": "A calendar field type providing functionality for recurrence.",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "type": "craft-plugin",
     "keywords": [
         "craft",

--- a/src/services/CalendarizeService.php
+++ b/src/services/CalendarizeService.php
@@ -394,8 +394,6 @@ class CalendarizeService extends Component
      */
     public function saveField(CalendarizeField $field, ElementInterface $owner): bool
     {
-        /** @var Element $owner */
-        $locale = $owner->getSite()->language;
         /** @var Map $value */
         $value = $owner->getFieldValue($field->handle);
 
@@ -427,7 +425,13 @@ class CalendarizeService extends Component
             $record->months         = $value->months ?? null;
 
             if (isset($value->endRepeatDate)) {
-                $record->endRepeatDate = Db::prepareDateForDb($value->endRepeatDate);
+                $endRepeat = $value->endRepeatDate;
+
+                if ($endRepeat instanceof DateTime) {
+                    $endRepeat->setTime(23, 59, 59);
+                }
+
+                $record->endRepeatDate = Db::prepareDateForDb($endRepeat);
             }
 
             if (isset($value->exceptions)) {


### PR DESCRIPTION
### Junior Review:
Yes

### Context:
On some installs of this plugin, the `endRepeatDate` works fine and automatically sets to `23:59:59`. However, some installs this is not the case and the end repeat time is set to `00:00:00`, ruling that day out. In these cases the end repeat needs to be set to the next day (which isn't great UX).

I'm sure there is some underlying reason for this - but I don't have time to look into it as this plugin has consumed enough resource with all its problems. The changes in this PR will always force the time to `23:59:59` when saving the field.

### Fixed
- `endRepeatDate` `DateTime` object time manually set to end of day (23:59:59).
