### PR TITLE
Fix array offset and last of month text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.4.4 - 2022-08-10
+### Added
+- `nesbot/carbon` package.
+
+### Changed
+- Locked package versions.
+
+### Fixed
+- `weekMonthText` service function to handle "last" occurrences.
+- `weekOfMonth` service function to correctly return data for the `RRULE` `BYDAY`.
+
 ## 1.4.3 - 2022-07-28
 ### Changed
 - JS to ordinals that match PHP

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unionco/calendarize",
     "description": "A calendar field type providing functionality for recurrence.",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "type": "craft-plugin",
     "keywords": [
         "craft",

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,10 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0-RC1",
+        "craftcms/cms": "^3.0",
         "ext-intl": "*",
-        "rlanvin/php-rrule": "~1.6.0"
+        "rlanvin/php-rrule": "^1.6",
+        "nesbot/carbon": "^2.59"
     },
     "autoload": {
         "psr-4": {

--- a/src/services/CalendarizeService.php
+++ b/src/services/CalendarizeService.php
@@ -11,6 +11,7 @@
 
 namespace unionco\calendarize\services;
 
+use Carbon\Carbon;
 use Craft;
 use craft\base\Component;
 use craft\base\ElementInterface;
@@ -35,17 +36,14 @@ use unionco\calendarize\records\CalendarizeRecord;
  */
 class CalendarizeService extends Component
 {
-    // Private Properties
-    // =========================================================================
-
     /** @var CalendarModel[] */
     private $entryCache = [];
 
-    // Public Methods
-    // =========================================================================
-
     /**
+     * Return text version of week number within the month for a given date.
      *
+     * @param $date
+     * @return string
      */
     public function weekMonthText($date): string
     {
@@ -55,17 +53,24 @@ class CalendarizeService extends Component
             Craft::$app->getUser()->getIdentity()->getPreferredLocale() ?? 'en-US', NumberFormatter::ORDINAL
         );
 
-        return $nf->format(ceil($date->format('j') / 7)) . ' ' . $date->format('l');
+        $weekNumber = Carbon::make($date)->weekNumberInMonth;
+
+        return ($weekNumber === 5 ? 'Last' : $nf->format($weekNumber)) . " {$date->format('l')}";
     }
 
     /**
+     * Return week number within the month for a given date.
      *
+     * @param $date
+     * @return int|null
      */
-    public function weekOfMonth($date): string
+    public function weekOfMonth($date): ?int
     {
-        if (!$date) return '';
-        $prefixes = [1, 2, 3, 4, -1];
-        return $prefixes[floor($date->format('j') / 7)];
+        if (! $date) return null;
+
+        $weekNumber = Carbon::make($date)->weekNumberInMonth;
+
+        return $weekNumber === 5 ? -1 : $weekNumber;
     }
 
     /**


### PR DESCRIPTION
### Context
There is currently a bug where repeat dates for an event that reoccurs on a month day are offset by a week, this is due to incorrect usage of an array (it isn't offset by 1).

I have instead moved to a more reliable way of working month weeks out with Carbon and providing an exception for the 5th week. This does mean that you cannot start an event that repeats on the "Last X of the Month" in a month with less than 5 occurrences of X day, but that was a problem anyway 🤷🏼‍♂️ and we don't have time to rebuild the frontend for this right now.

### Added
- `nesbot/carbon` package.

### Changed
- Locked package versions.

### Fixed
- `weekMonthText` service function to handle "last" occurrences.
- `weekOfMonth` service function to correctly return data for the `RRULE` `BYDAY`.

